### PR TITLE
Add on-screen event log.

### DIFF
--- a/src/controller/ActorController.java
+++ b/src/controller/ActorController.java
@@ -4,6 +4,8 @@ import actor.Actor;
 import game.Direction;
 import game.Game;
 import game.Physical;
+import game.display.Event;
+import game.display.EventLog;
 import world.Coordinate;
 import world.World;
 
@@ -47,7 +49,7 @@ public abstract class ActorController implements Controller {
       return;
     }
     if (grabbing.isImmovable()) {
-      System.out.println("Tried to grab an immovable physical.");
+      EventLog.registerEvent(Event.INVALID_ACTION,"That can't be picked up.");
       return;
     }
 
@@ -60,7 +62,7 @@ public abstract class ActorController implements Controller {
 
   public final void startDropping(Physical dropping, Coordinate droppingAt) {
     if (droppingAt.getSquare().isBlocked()) {
-      System.out.println("Tried to drop on a blocked square.");
+      EventLog.registerEvent(Event.INVALID_ACTION, "There's no room there.");
       return;
     }
 
@@ -120,7 +122,7 @@ public abstract class ActorController implements Controller {
 
       } else {
 
-        onMoveFailed();
+        onActionFailed(Action.MOVING, "Can't move there.");
 
       }
 
@@ -129,7 +131,7 @@ public abstract class ActorController implements Controller {
       if (grabbingAt.getSquare().pull(grabbing)) {
         actor.getInventory().addItem(grabbing);
       } else {
-        System.out.println("Tried to grab a physical that already moved.");
+        onActionFailed(Action.GRABBING, "The thing you were reaching for is no longer there.");
       }
 
       grabbing = null;
@@ -141,7 +143,7 @@ public abstract class ActorController implements Controller {
       if (actor.getInventory().removeItem(dropping)){
         droppingAt.getSquare().put(dropping);
       } else {
-        System.out.println("Tried to drop a physical that actor didn't have.");
+        onActionFailed(Action.DROPPING,"You can't seem to find the thing you were trying to drop.");
       }
 
       grabbing = null;
@@ -162,10 +164,11 @@ public abstract class ActorController implements Controller {
   protected void onMoveSucceeded() { }
 
   /**
-   * Subclasses of ActorController should override this method to hook into failed movement,
-   * typically caused by colliding with a tree or some other blocking Physical.
+   * Subclasses of ActorController should override this method to hook into game updates. This
+   * function is run at the end of this ActorController's onUpdate() call, and should be used to
+   * setup the actor for FUTURE updates, rather than the current one.
    */
-  protected void onMoveFailed() { }
+  protected void onActionFailed(Action action, String message) { }
 
   /**
    * Subclasses of ActorController should override this method to hook into game updates. This

--- a/src/controller/AnimalController.java
+++ b/src/controller/AnimalController.java
@@ -67,8 +67,10 @@ public class AnimalController extends ActorController {
   }
 
   @Override
-  protected void onMoveFailed() {
-    stopWander();
+  protected void onActionFailed(Action action, String message) {
+    if (action == Action.MOVING) {
+      stopWander();
+    }
   }
 
   @Override

--- a/src/controller/player/PlayerController.java
+++ b/src/controller/player/PlayerController.java
@@ -1,7 +1,10 @@
 package controller.player;
 
 import actor.Actor;
+import controller.Action;
 import controller.ActorController;
+import game.display.Event;
+import game.display.EventLog;
 import utils.Dimension;
 import world.Coordinate;
 
@@ -27,6 +30,14 @@ public class PlayerController extends ActorController {
     // Update WorldMapRevealed component accordingly.
       component_worldMapRevealed.setAreaIsRevealed(getCoordinate());
 
+  }
+
+  @Override
+  protected void onActionFailed(Action action, String message) {
+    if (action == Action.MOVING) {
+      return; // failed move messages are too spammy and not really necessary.
+    }
+    EventLog.registerEvent(Event.INVALID_ACTION, message);
   }
 
   @Override

--- a/src/game/display/AreaPanel.java
+++ b/src/game/display/AreaPanel.java
@@ -49,5 +49,8 @@ public class AreaPanel extends JPanel {
 
       }
     }
+
+    EventLog.drawOverlayed((Graphics2D)g);
+
   }
 }

--- a/src/game/display/Event.java
+++ b/src/game/display/Event.java
@@ -1,0 +1,22 @@
+package game.display;
+
+import java.awt.*;
+
+/**
+ *
+ */
+public class Event {
+
+  public static final Color INVALID_ACTION = Color.ORANGE;
+
+
+  final long timePosted;
+  final Color color;
+  final String message;
+
+  public Event(Color color, String message) {
+    this.timePosted = System.currentTimeMillis();
+    this.color = color;
+    this.message = message;
+  }
+}

--- a/src/game/display/EventLog.java
+++ b/src/game/display/EventLog.java
@@ -15,6 +15,8 @@ import java.util.List;
  */
 public class EventLog {
 
+  public static final double TOP_OR_BOTTOM_SWAP_LINE = 0.75;
+
 
   // VALUES IN MILLISECONDS
   public static final long EVENT_LIFESPAN = 5000;
@@ -77,8 +79,7 @@ public class EventLog {
     final int areaHeight = areaSizeInSquares.getHeight();
 
 
-
-    boolean drawingTop = (playerAt.localY > areaHeight /2);
+    boolean drawingTop = (playerAt.localY > areaHeight * TOP_OR_BOTTOM_SWAP_LINE);
 
     int linesTall = getLinesTall();
 

--- a/src/game/display/EventLog.java
+++ b/src/game/display/EventLog.java
@@ -1,0 +1,118 @@
+package game.display;
+
+import game.Game;
+import utils.Dimension;
+import utils.Utils;
+import world.Coordinate;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ *
+ */
+public class EventLog {
+
+
+  // VALUES IN MILLISECONDS
+  public static final long EVENT_LIFESPAN = 5000;
+
+  // VALUES IN PIXELS
+  public static final int LINE_HEIGHT = 15;
+  public static final int LINE_SPACER = LINE_HEIGHT/3;
+
+  // VALUES IN LINES
+  public static final int MINIMUM_HEIGHT = 5;
+  public static final int MAXIMUM_HEIGHT = 10;
+
+
+  public static final Font SMALL_TEXT = new Font("Monospaced", Font.PLAIN, LINE_HEIGHT);
+
+
+
+
+  private static int liveEventsIndex = 0;
+  private static final List<Event> events = new ArrayList<>();
+
+
+
+  private static int getLinesTall() {
+    return Utils.clamp(events.size() - liveEventsIndex,MINIMUM_HEIGHT,MAXIMUM_HEIGHT);
+  }
+
+
+
+  public static void registerEvent(Color color, String message) {
+    events.add(new Event(color,message));
+  }
+
+
+
+  public static void drawOverlayed(Graphics2D g2d) {
+
+    g2d.setFont(SMALL_TEXT);
+
+
+    // check for expired events and push live events index forward accordingly
+    boolean allDead = true;
+    for (int i = liveEventsIndex; i < events.size(); i++) {
+      if (System.currentTimeMillis() - events.get(i).timePosted < EVENT_LIFESPAN) {
+        liveEventsIndex = i;
+        allDead = false;
+        break;
+      }
+    }
+
+    if (allDead) {
+      return; // draw nothing if there's no messages.
+    }
+
+
+    Coordinate playerAt = Game.getActivePlayer().getCoordinate();
+
+    Dimension areaSizeInSquares = Game.getActiveWorld().getAreaSizeInSquares();
+
+    final int areaHeight = areaSizeInSquares.getHeight();
+
+
+
+    boolean drawingTop = (playerAt.localY > areaHeight /2);
+
+    int linesTall = getLinesTall();
+
+    int drawWidth = (int) (LINE_HEIGHT*areaSizeInSquares.getWidth()*0.65);
+    int drawHeight = LINE_HEIGHT * linesTall + LINE_SPACER;
+    int drawX = areaSizeInSquares.getWidth()/2*LINE_HEIGHT - drawWidth/2;
+    int drawY;
+
+    if (drawingTop) {
+      drawY = LINE_SPACER;
+    }
+    else {
+      drawY = GameDisplay.SQUARE_SIZE * areaHeight - drawHeight;
+    }
+
+    g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.75f));
+    g2d.setColor(Color.BLACK);
+    g2d.fillRect(drawX, drawY, drawWidth, drawHeight);
+    g2d.setColor(Color.DARK_GRAY);
+    g2d.drawRect(drawX,drawY,drawWidth,drawHeight);
+
+
+    // draw live event messages, bottom-up, for as long as there's room
+
+    for (int i = 0; i < events.size()-liveEventsIndex && i < linesTall; i++) {
+
+      Event event = events.get(events.size()-1-i);
+
+      g2d.setColor(event.color);
+      g2d.drawString(event.message,drawX + 10,drawY+drawHeight-LINE_HEIGHT*i-LINE_SPACER);
+
+    }
+
+  }
+
+
+}


### PR DESCRIPTION
Closes #30. There is now a small event log in the bottom middle of the screen. Messages registered currently last 5 seconds of real time, then vanish. It is hidden when there are no active messages, and can expand when there are many (up to a limit). Currently only invalid grabs/drops will trigger any sort of message.
