### PR TITLE
Add event log with overlay mode toggle

### DIFF
--- a/src/game/display/EventLog.java
+++ b/src/game/display/EventLog.java
@@ -31,49 +31,75 @@ public class EventLog {
   // VALUES IN LINES
   public static final int MINIMUM_HEIGHT = 5;
   public static final int MAXIMUM_HEIGHT = 10;
-
+  public static final int MAX_LOG_LINES = 15;  // 15 lines. 1 for the esc message
 
   public static final Font SMALL_TEXT = new Font("Monospaced", Font.PLAIN, LINE_HEIGHT);
+  private static int startingEvent = 1;
 
-
-
-
+  private static boolean expandedMode = false;
   private static int liveEventsIndex = 0;
   private static final List<Event> events = new ArrayList<>();
 
+  public static void scrollLogDown() {
+    if (--startingEvent < 1) {
+      startingEvent = 1;
+    }
+  }
 
-
+  public static void scrollLogUp() {
+    if (++startingEvent > events.size()) {
+      startingEvent = events.size();
+    }
+  }
   private static int getLinesTall() {
     return Utils.clamp(events.size() - liveEventsIndex,MINIMUM_HEIGHT,MAXIMUM_HEIGHT);
   }
 
-
+  private static boolean findLiveEvents() {
+    // Search for live events and push live events index forward accordingly
+    boolean anyLive = false;
+    for (int i = liveEventsIndex; i < events.size(); i++) {
+      if (System.currentTimeMillis() - events.get(i).timePosted < EVENT_LIFESPAN) {
+        liveEventsIndex = i;
+        anyLive = true;
+        break;
+      }
+    }
+    return anyLive;
+  }
 
   public static void registerEvent(Color color, String message) {
     events.add(new Event(color,message));
   }
 
+  public static void registerEventIfPlayerIsNear(Coordinate nearTo, Color color, String message) {
+    if (Game.getActivePlayer().getActor().getCoordinate().area == nearTo.area) {
+      registerEvent(color, message);
+    }
+  }
+  public static boolean showEventLog() {
+    expandedMode = true;
+    return true;
+  }
 
+  public static boolean hideEventLog() {
+    expandedMode = false;
+    return false;
+  }
+
+  public static boolean getExpandedMode() { return expandedMode; }
 
   public static void drawOverlay(Graphics2D g2d) {
 
+    if (Game.RANDOM.nextInt(100) < 1) {
+      registerEvent(Color.BLUE, Double.toString(Game.RANDOM.nextDouble()));
+    }
+
+    // Look for live events. if there are none and we're not in expanded mode then exit.
+    if (!findLiveEvents() && !expandedMode) {
+      return;
+    }
     g2d.setFont(SMALL_TEXT);
-
-
-    // check for expired events and push live events index forward accordingly
-    boolean allDead = true;
-    for (int i = liveEventsIndex; i < events.size(); i++) {
-      if (System.currentTimeMillis() - events.get(i).timePosted < EVENT_LIFESPAN) {
-        liveEventsIndex = i;
-        allDead = false;
-        break;
-      }
-    }
-
-    if (allDead) {
-      return; // draw nothing if there's no messages.
-    }
-
 
     Coordinate playerAt = Game.getActivePlayer().getActor().getCoordinate();
 
@@ -81,14 +107,16 @@ public class EventLog {
 
     final int areaHeight = areaSizeInSquares.getHeight();
 
-
     boolean drawingTop = (playerAt.localY > areaHeight * TOP_OR_BOTTOM_SWAP_LINE);
-
     int linesTall = getLinesTall();
 
-    int drawWidth = (int) (LINE_HEIGHT*areaSizeInSquares.getWidth()*0.65);
+    if (expandedMode) {
+      linesTall = MAX_LOG_LINES;
+    }
+
+    int drawWidth = (int) (LINE_HEIGHT * areaSizeInSquares.getWidth() * 0.65);
     int drawHeight = LINE_HEIGHT * linesTall + LINE_SPACER;
-    int drawX = areaSizeInSquares.getWidth()/2*LINE_HEIGHT - drawWidth/2;
+    int drawX = areaSizeInSquares.getWidth() / 2 * LINE_HEIGHT - drawWidth / 2;
     int drawY;
 
     if (drawingTop) {
@@ -102,26 +130,50 @@ public class EventLog {
     g2d.setColor(Color.BLACK);
     g2d.fillRect(drawX, drawY, drawWidth, drawHeight);
     g2d.setColor(Color.DARK_GRAY);
-    g2d.drawRect(drawX,drawY,drawWidth,drawHeight);
+    g2d.drawRect(drawX, drawY, drawWidth, drawHeight);
+    if (expandedMode) {
+      drawEventLog(g2d, linesTall, drawX, drawY, drawHeight);
+    }
+    else {
+      drawLiveEvents(g2d, linesTall, drawX, drawY, drawHeight);
+    }
 
+  }
+
+  private static void drawLiveEvents(Graphics2D g2d, int linesTall, int drawX, int drawY, int drawHeight) {
 
     // draw live event messages, bottom-up, for as long as there's room
+    for (int i = 0; i < events.size() - liveEventsIndex && i < linesTall; i++) {
 
-    for (int i = 0; i < events.size()-liveEventsIndex && i < linesTall; i++) {
-
-      Event event = events.get(events.size()-1-i);
+      Event event = events.get(events.size() - 1 - i);
 
       g2d.setColor(event.color);
-      g2d.drawString(event.message,drawX + 10,drawY+drawHeight-LINE_HEIGHT*i-LINE_SPACER);
-
-    }
-
-  }
-
-  public static void registerEventIfPlayerIsNear(Coordinate nearTo, Color color, String message) {
-    if (Game.getActivePlayer().getActor().getCoordinate().area == nearTo.area) {
-      registerEvent(color, message);
+      g2d.drawString(event.message, drawX + 10, drawY + drawHeight - LINE_HEIGHT * i - LINE_SPACER);
     }
   }
 
+  public static void drawEventLog(Graphics2D g2d, int linesTall, int drawX, int drawY, int drawHeight) {
+
+    // Draw MAX_LOG_LINES number of lines. Including one for the exit message.
+    g2d.setColor(Color.WHITE);
+    g2d.drawString("(Esc to exit)", drawX + 10, drawY + drawHeight - LINE_SPACER);
+
+    for (int i = 0; i < (MAX_LOG_LINES - 1); i++) {
+
+      int eventsIndex = events.size() - i - startingEvent;
+      if (eventsIndex < 0) {
+        break;
+      }
+      Event event = events.get(eventsIndex);
+      g2d.setColor(event.color);
+      String message;
+      if (eventsIndex >= liveEventsIndex) {
+        message = ">" + event.message;
+      }
+      else {
+        message = " " + event.message;
+      }
+      g2d.drawString(message, drawX + 10, drawY + drawHeight - LINE_HEIGHT * (i + 1) - LINE_SPACER);
+    }
+  }
 }

--- a/src/game/input/Commands_EnterMode.java
+++ b/src/game/input/Commands_EnterMode.java
@@ -128,8 +128,25 @@ public enum Commands_EnterMode implements Command {
       Game.getActiveInputSwitch().enterMode(GameMode.INVENTORY);
     }
 
+  },
+
+  ENTER_MODE_EVENTLOG {
+
+    @Override
+    public int getHotKeyCode() {
+      return KeyEvent.VK_E;
+    }
+
+    @Override
+    public String getControlText() {
+      return "E: Open event log.";
+    }
+
+    @Override
+    public void execute() {
+      Game.getActiveInputSwitch().enterMode(GameMode.EVENTLOG);
+    }
+
   }
-
-
 
 }

--- a/src/game/input/Commands_EventLog.java
+++ b/src/game/input/Commands_EventLog.java
@@ -1,0 +1,58 @@
+package game.input;
+
+import actor.Actor;
+import controller.action.Attacking;
+import controller.action.PickingUp;
+import controller.player.PlayerController;
+import game.Game;
+import game.display.Event;
+import game.display.EventLog;
+import game.physical.Physical;
+
+import java.awt.event.KeyEvent;
+
+/**
+ *
+ */
+public enum Commands_EventLog implements Command {
+
+
+  SCROLL_DOWN {
+
+    @Override
+    public int getHotKeyCode() {
+      return KeyEvent.VK_OPEN_BRACKET;
+    }
+
+    @Override
+    public String getControlText() {
+      return "[: Scroll down.";
+    }
+
+    @Override
+    public void execute() {
+      EventLog.scrollLogDown();
+    }
+
+  },
+
+  SCROLL_UP {
+
+    @Override
+    public int getHotKeyCode() {
+      return KeyEvent.VK_CLOSE_BRACKET;
+    }
+
+    @Override
+    public String getControlText() {
+      return "]: Scroll up.";
+    }
+
+    @Override
+    public void execute() {
+      EventLog.scrollLogUp();
+    }
+
+  }
+
+}

--- a/src/game/input/Commands_EventLog.java
+++ b/src/game/input/Commands_EventLog.java
@@ -64,12 +64,19 @@ public enum Commands_EventLog implements Command {
 
     @Override
     public String getControlText() {
-      return "F: Toggle overlay mode.";
+      if (EventLog.getExpandedMode() == 1) {
+        return "F: Minimize overlay";
+      }
+      else {
+        return "F: Maximize overlay.";
+      }
+
     }
 
     @Override
     public void execute() {
       EventLog.toggleLogMode();
+      Game.getActiveInputSwitch().enterMode(GameMode.EXPLORE);
     }
 
   }

--- a/src/game/input/Commands_EventLog.java
+++ b/src/game/input/Commands_EventLog.java
@@ -53,6 +53,26 @@ public enum Commands_EventLog implements Command {
       EventLog.scrollLogUp();
     }
 
+  },
+
+  TOGGLE_MODE {
+
+    @Override
+    public int getHotKeyCode() {
+      return KeyEvent.VK_F;
+    }
+
+    @Override
+    public String getControlText() {
+      return "F: Toggle overlay mode.";
+    }
+
+    @Override
+    public void execute() {
+      EventLog.toggleLogMode();
+    }
+
   }
+
 
 }

--- a/src/game/input/GameMode.java
+++ b/src/game/input/GameMode.java
@@ -192,11 +192,16 @@ public enum GameMode {
     @Override
     public void onEnter() {
       EventLog.showEventLog();
+
+      if (Game.getTimeMode() == TimeMode.LIVE || Game.getTimeMode() == TimeMode.PRECISION) {
+        Game.setTimeMode(TimeMode.PAUSED);
+      }
+
     }
 
     @Override
     public String getPrompt() {
-      return null;
+      return "Viewing Event Log";
     }
 
     @Override
@@ -204,7 +209,8 @@ public enum GameMode {
       return Arrays.asList(
               Commands_EnterMode.ENTER_MODE_EXPLORE,
               Commands_EventLog.SCROLL_DOWN,
-              Commands_EventLog.SCROLL_UP
+              Commands_EventLog.SCROLL_UP,
+              Commands_EventLog.TOGGLE_MODE
       );
     }
 
@@ -214,6 +220,7 @@ public enum GameMode {
       return Arrays.asList(
               DisplayElement.MINIMAP,
               DisplayElement.CONTROL_ESCAPE,
+              DisplayElement.makeCurrentPrompt(),
               DisplayElement.makeControlsList(getModeCommands(), 1)
       );
 

--- a/src/game/input/GameMode.java
+++ b/src/game/input/GameMode.java
@@ -4,6 +4,7 @@ import game.Game;
 import game.TimeMode;
 import game.display.DisplayElement;
 import game.display.DisplayElement_Text;
+import game.display.EventLog;
 import world.Coordinate;
 
 import java.util.Arrays;
@@ -21,7 +22,7 @@ public enum GameMode {
 
     @Override
     public void onEnter() {
-
+      EventLog.hideEventLog();
       if (Game.getTimeMode() == TimeMode.PAUSED) {
         Game.revertTimeMode();
       }
@@ -39,7 +40,8 @@ public enum GameMode {
           Commands_EnterMode.TOGGLE_PRECISION_TIME,
           Commands_EnterMode.ENTER_MODE_LOOK,
           Commands_EnterMode.ENTER_MODE_INTERACT,
-          Commands_EnterMode.ENTER_MODE_INVENTORY
+          Commands_EnterMode.ENTER_MODE_INVENTORY,
+          Commands_EnterMode.ENTER_MODE_EVENTLOG
       );
     }
 
@@ -183,7 +185,42 @@ public enum GameMode {
 
     }
 
+  },
+
+  EVENTLOG {
+
+    @Override
+    public void onEnter() {
+      EventLog.showEventLog();
+    }
+
+    @Override
+    public String getPrompt() {
+      return null;
+    }
+
+    @Override
+    public List<Command> getModeCommands() {
+      return Arrays.asList(
+              Commands_EnterMode.ENTER_MODE_EXPLORE,
+              Commands_EventLog.SCROLL_DOWN,
+              Commands_EventLog.SCROLL_UP
+      );
+    }
+
+    @Override
+    public List<DisplayElement> getDisplayElements() {
+
+      return Arrays.asList(
+              DisplayElement.MINIMAP,
+              DisplayElement.CONTROL_ESCAPE,
+              DisplayElement.makeControlsList(getModeCommands(), 1)
+      );
+
+    }
+
   };
+
 
 
   public abstract void onEnter();


### PR DESCRIPTION
Event log code that shows a large event log when viewed and allows scrolling up and down. The event log can be toggled to a small mode that shows only 5 lines and is on all the time when in explore mode. When the event log is toggled to small mode it automatically returns to explore mode.
